### PR TITLE
Add standard exits

### DIFF
--- a/plasma_cli.go
+++ b/plasma_cli.go
@@ -448,7 +448,7 @@ func (s *standardExitUTXOData) plasmaStartStandardExit(ethereumClient string, co
 	}
 }
 
-//Make strings suitble for hex encoding
+//Make strings suitable for hex encoding
 func removeLeadingZeroX(item string) string {
 	cleanedString := strings.Replace(item, "0x", "", -1)
 	return cleanedString


### PR DESCRIPTION
https://rinkeby.etherscan.io/tx/0xfd891ca94ac0042e629b71ce71ef0e9a66f85cb0e0398391bd3dd476e13e3144

```
INFO[2019-02-13T11:43:36+07:00] Starting OmiseGO Plasma MoreVP CLI
INFO[2019-02-13T11:43:36+07:00] Attempting to exit UTXO 1000000000
INFO[2019-02-13T11:43:36+07:00] Getting data needed to exit the UTXO from the Watcher
INFO[2019-02-13T11:43:37+07:00] 200 OK
INFO[2019-02-13T11:43:39+07:00] Proof: 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563633dc4d7da7256660a892f8f1604a44b5432649cc8ec5cb3ced4c4e6ac94dd1d890740a8eb06ce9be422cb8da5cdafc2b58c0a5e24036c578de2a433c828ff7d3b8ec09e026fdc305365dfc94e189a81b38c7597b3d941c279f042e8206e0bd8ecd50eee38e386bd62be9bedb990706951b65fe053bd9d8a521af753d139e2dadefff6d330bb5403f63b14f33b578274160de3a50df4efecf0e0db73bcdd3da5617bdd11f7c0a11f49db22f629387a12da7596f9d1704d7465177c63d88ec7d7292c23a9aa1d8bea7e2435e555a4a60e379a5a35f3f452bae60121073fb6eeade1cea92ed99acdcb045a6726b2f87107e8a61620a232cf4d7d5b5766b3952e107ad66c0a68c72cb89e4fb4303841966e4062a76ab97451e3b9fb526a5ceb7f82e026cc5a4aed3c22a58cbd3d2ac754c9352c5436f638042dca99034e836365163d04cffd8b46a874edf5cfae63077de85f849a660426697b06a829c70dd1409cad676aa337a485e4728a0b240d92b3ef7b3c372d06d189322bfd5f61f1e7203ea2fca4a49658f9fab7aa63289c91b7c7b6c832a6d0e69334ff5b0a3483d09dab4ebfd9cd7bca2505f7bef59cc1c12ecc708fff26ae4af19abe852afe9e20c8622def10d13dd169f550f578bda343d9717a138562e0093b380a1120789d53cf10
INFO[2019-02-13T11:43:39+07:00] TxBytes: 0xf8c3d0c3808080c3808080c3808080c3808080f8b0eb94944a81beecac91802787fbcfb9767fcbf81db1f594000000000000000000000000000000000000000064eb94000000000000000000000000000000000000000094000000000000000000000000000000000000000080eb94000000000000000000000000000000000000000094000000000000000000000000000000000000000080eb94000000000000000000000000000000000000000094000000000000000000000000000000000000000080
INFO[2019-02-13T11:43:39+07:00] UTXO Position: 1000000000
INFO[2019-02-13T11:43:39+07:00] Encoded TXBytes: [248 195 208 195 128 128 128 195 128 128 128 195 128 128 128 195 128 128 128 248 176 235 148 148 74 129 190 236 172 145 128 39 135 251 207 185 118 127 203 248 29 177 245 148 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 100 235 148 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 148 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 128 235 148 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 148 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 128 235 148 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 148 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 128]
INFO[2019-02-13T11:43:39+07:00] Encoded Proof: [41 13 236 217 84 139 98 168 214 3 69 169 136 56 111 200 75 166 188 149 72 64 8 246 54 47 147 22 14 243 229 99 99 61 196 215 218 114 86 102 10 137 47 143 22 4 164 75 84 50 100 156 200 236 92 179 206 212 196 230 172 148 221 29 137 7 64 168 235 6 206 155 228 34 203 141 165 205 175 194 181 140 10 94 36 3 108 87 141 226 164 51 200 40 255 125 59 142 192 158 2 111 220 48 83 101 223 201 78 24 154 129 179 140 117 151 179 217 65 194 121 240 66 232 32 110 11 216 236 213 14 238 56 227 134 189 98 190 155 237 185 144 112 105 81 182 95 224 83 189 157 138 82 26 247 83 209 57 226 218 222 255 246 211 48 187 84 3 246 59 20 243 59 87 130 116 22 13 227 165 13 244 239 236 240 224 219 115 188 221 61 165 97 123 221 17 247 192 161 31 73 219 34 246 41 56 122 18 218 117 150 249 209 112 77 116 101 23 124 99 216 142 199 215 41 44 35 169 170 29 139 234 126 36 53 229 85 164 166 14 55 154 90 53 243 244 82 186 230 1 33 7 63 182 238 173 225 206 169 46 217 154 205 203 4 90 103 38 178 248 113 7 232 166 22 32 162 50 207 77 125 91 87 102 179 149 46 16 122 214 108 10 104 199 44 184 158 79 180 48 56 65 150 110 64 98 167 106 185 116 81 227 185 251 82 106 92 235 127 130 224 38 204 90 74 237 60 34 165 140 189 61 42 199 84 201 53 44 84 54 246 56 4 45 202 153 3 78 131 99 101 22 61 4 207 253 139 70 168 116 237 245 207 174 99 7 125 232 95 132 154 102 4 38 105 123 6 168 41 199 13 209 64 156 173 103 106 163 55 164 133 228 114 138 11 36 13 146 179 239 123 60 55 45 6 209 137 50 43 253 95 97 241 231 32 62 162 252 164 164 150 88 249 250 183 170 99 40 156 145 183 199 182 200 50 166 208 230 147 52 255 91 10 52 131 208 157 171 78 191 217 205 123 202 37 5 247 190 245 156 193 193 46 204 112 143 255 38 174 74 241 154 190 133 42 254 158 32 200 98 45 239 16 209 61 209 105 245 80 245 120 189 163 67 217 113 122 19 133 98 224 9 59 56 10 17 32 120 157 83 207 16]
INFO[2019-02-13T11:43:40+07:00] Standard exit to Plasma MoreVP sent. Transaction: 0xfd891ca94ac0042e629b71ce71ef0e9a66f85cb0e0398391bd3dd476e13e3144
```
