### PR TITLE
added support for creating keypair

### DIFF
--- a/plasma_cli.go
+++ b/plasma_cli.go
@@ -55,7 +55,8 @@ var (
 	processToken = process.Flag("token", "Token address to process for standard exits").Required().String()
 	processPrivateKey = process.Flag("privatekey", "Private key used to fund the gas for the smart contract call").Required().String()
 	processExitClient = process.Flag("client", "Address of the Ethereum client. Infura and local node supported https://rinkeby.infura.io/v3/api_key or http://localhost:8545").Required().String()
-	createAccount = kingpin.Command("create_account", "Create an account consisting of Public and Private key")
+	create = kingpin.Command("create", "Create a resource.")
+	createAccount = create.Command("account", "Create an account consisting of Public and Private key")
 )
 
 type processExit struct {
@@ -620,7 +621,7 @@ func main() {
 		log.Info("Calling process exits in the Plasma contract")
 		p.plasmaProcessExits(100)
 	case createAccount.FullCommand():
-		//plasma_cli create_account 
+		//plasma_cli create account 
 		log.Info("Generating Keypair")
 		generateAccount()
 	}


### PR DESCRIPTION
https://github.com/omisego/plasma-cli/issues/9 Creating Keypair (address and Privatekey)
Logging it onto the screen for now

`go run plasma_cli.go create_account`

```
INFO[2019-02-14T11:11:53+07:00] Generating Keypair
INFO[2019-02-14T11:11:53+07:00] Address is 0xc26c926c3970a9002779d97fb8Fa8785E5025b2a
INFO[2019-02-14T11:11:53+07:00] Privatekey is cb045b12f4d80f2116189191bce7f38f77297a56037cc2baf29242ce9da855c7
```
