### PR TITLE
Implementing Split Transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # OmiseGO Plasma CLI
 
-## What is this?
-
 The Plasma CLI is used to interact with the OMG network from the command line. Technical details about Ethereum and Plasma are abstracted from the user.
 
 Plasma CLI enables the user to:
 * deposit ETH to the Plasma contract
-* create transactions
+* create send, split and merge transactions
 * exit ETH from the OMG Network back to Ethereum
 
 Connectivity to Ethereum via a local RPC node or Infura is supported.
@@ -31,41 +29,46 @@ plasma_cli create account
 ## Deposit ETH into the OMG Network
 
 ```
-plasma_cli deposit --privatekey=<private key> --client=<local rpc server or Infura URL> --contract=<contract address> --amount=<amount in wei> --owner=<public key of the owner>
+plasma_cli deposit --privatekey="private_key" --client="local_rpc_server_or_Infura_URL" --contract="contract_address" --amount=amount_in_wei --owner="owner_address"
 ```
 
 
 ## Retrieve a List of UTXOs
 
 ```
-plasma_cli get utxos --watcher=<watcher URL> --address=<public_address>
+plasma_cli get utxos --watcher="watcher_URL" --address="public_address"
 ```
 
 ## Check the Balance of an Account
 
 ```
-plasma_cli get balance --watcher=<watcher URL> --address=<public_address>
+plasma_cli get balance --watcher="watcher_URL" --address="public_address"
 ```
-
 ## Sending ETH UTXO
 
-This function will either
-1. Send the entire UTXO to an address, or
-2. Split the UTXO to destination address and send the change to the owner
+Send an entire UTXO to an address, sends change back to sender if available
 
 ```
-plasma_cli send --fromutxo=<UTXO position> --fromowner=<from address> --privatekey=<from privatekey> --toowner=<to address> --toamount=<to amount>  --watcher=<watcher url>
+plasma_cli send --fromutxo=UTXO_position --fromowner="from_address" --privatekey="from_privatekey" --toowner="to_address" --toamount=to_amount  --watcher="watcher_url"
+```
+
+## Split ETH UTXO
+
+Split an entire UTXO input into N outputs to an address, sends change back to sender if available
+
+```
+plasma_cli split --fromutxo=UTXO_position --fromowner="from_address" --privatekey="from_privatekey" --toowner="to_address" --toamount=to_amount  --outputs=number_of_outputs --watcher="watcher_url"
 ```
 
 ## Merging ETH UTXOs
 
-This function allows for merging 4 or less UTXOs into 1
+Merge 4 or less UTXOs input into 1 output to owner
 ```
-plasma_cli merge --fromutxo=UTXO_1 --fromutxo=UTXO_2 --fromutxo=UTXO_3 --privatekey="private_key" --fromowner="from-owner"
+plasma_cli merge --fromutxo=UTXO_1 --fromutxo=UTXO_2 --fromutxo=UTXO_3 --privatekey="private_key" --fromowner="from_owner" --watcher="warcher_url"
 ```
 
 ## Exit to Ethereum
 
 ```
-plasma_cli exit --utxo=<utxo ID> --privatekey=<private key> --contract=<contract address> --watcher=<watcher url> --client=<local rpc server or Infura URL>
+plasma_cli exit --utxo=UTXO_position --privatekey="private_key" --contract="contract_address" --watcher="watcher_url" --client="local_rpc_server_or_Infura_URL"
 ```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ plasma_cli get balance --watcher="watcher_URL" --address="public_address"
 Send an entire UTXO to an address, sends change back to sender if available
 
 ```
-plasma_cli send --fromutxo=UTXO_position --fromowner="from_address" --privatekey="from_privatekey" --toowner="to_address" --toamount=to_amount  --watcher="watcher_url"
+plasma_cli send --fromutxo=UTXO_position --privatekey="from_privatekey" --toowner="to_address" --toamount=to_amount  --watcher="watcher_url"
 ```
 
 ## Split ETH UTXO
@@ -57,14 +57,14 @@ plasma_cli send --fromutxo=UTXO_position --fromowner="from_address" --privatekey
 Split an entire UTXO input into N outputs to an address, sends change back to sender if available
 
 ```
-plasma_cli split --fromutxo=UTXO_position --fromowner="from_address" --privatekey="from_privatekey" --toowner="to_address" --toamount=to_amount  --outputs=number_of_outputs --watcher="watcher_url"
+plasma_cli split --fromutxo=UTXO_position --privatekey="from_privatekey" --toowner="to_address" --toamount=to_amount  --outputs=number_of_outputs --watcher="watcher_url"
 ```
 
 ## Merging ETH UTXOs
 
 Merge 4 or less UTXOs input into 1 output to owner
 ```
-plasma_cli merge --fromutxo=UTXO_1 --fromutxo=UTXO_2 --fromutxo=UTXO_3 --privatekey="private_key" --fromowner="from_owner" --watcher="warcher_url"
+plasma_cli merge --fromutxo=UTXO_1 --fromutxo=UTXO_2 --fromutxo=UTXO_3 --privatekey="private_key" --watcher="warcher_url"
 ```
 
 ## Exit to Ethereum

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -42,7 +42,6 @@ var (
 
 	send             = kingpin.Command("send", "Create a transaction on the OmiseGO Plasma MoreVP network")
 	toowner          = send.Flag("toowner", "New owner of the UTXO").Required().String()
-	fromowner        = send.Flag("fromowner", "from an owner of the UTXO").Required().String()
 	privatekey       = send.Flag("privatekey", "privatekey to sign from owner of original UTXO").Required().String()
 	toamount         = send.Flag("toamount", "Amount to transact").Required().Uint()
 	fromutxo         = send.Flag("fromutxo", "utxo position to send from").Required().Uint()
@@ -50,7 +49,6 @@ var (
 
 	split             = kingpin.Command("split", "Create a transaction on the OmiseGO Plasma MoreVP network")
 	stoowner          = split.Flag("toowner", "New owner of the UTXO").Required().String()
-	sfromowner        = split.Flag("fromowner", "from an owner of the UTXO").Required().String()
 	sprivatekey       = split.Flag("privatekey", "privatekey to sign from owner of original UTXO").Required().String()
 	stoamount         = split.Flag("toamount", "Amount to transact").Required().Uint()
 	sfromutxo         = split.Flag("fromutxo", "utxo position to send from").Required().Uint()
@@ -66,7 +64,6 @@ var (
 
 	merge           = kingpin.Command("merge", "Standard exit a UTXO back to the root chain.")
 	mergeFromUtxos  = merge.Flag("fromutxo", "comma seperated utxo numbers you want to merge").Required().Uint64List()
-	mergeFromOwner  = merge.Flag("fromowner", "from an address ").Required().String()
 	mergeWatcherURL = merge.Flag("watcher", "FQDN of the Watcher in the format http://watcher.path.net").Required().String()
 	mergePrivateKey = merge.Flag("privatekey", "Private key of the UTXO owner").Required().String()
 
@@ -108,8 +105,9 @@ func ParseArgs() {
 		d := plasma.PlasmaDeposit{PrivateKey: *privateKey, Client: *client, Contract: *contract, Amount: *depositAmount, Owner: *depositOwner, Currency: *depositCurrency}
 		d.DepositToPlasmaContract()
 	case send.FullCommand():
-		//plasma_cli send --fromutxo --fromowner --privatekey --toowner --toamount --watcher
-		p := plasma.GetUTXO(*fromowner, *fromutxo, *watcherSubmitURL)
+		//plasma_cli send --fromutxo --privatekey --toowner --toamount --watcher
+		k := util.DeriveAddress(*privatekey)
+		p := plasma.GetUTXO(k, *fromutxo, *watcherSubmitURL)
 
 		c := plasma.PlasmaTransaction{
 			Blknum:     uint(p.Blknum),
@@ -117,37 +115,40 @@ func ParseArgs() {
 			Oindex:     uint(p.Oindex),
 			Cur12:      common.HexToAddress(p.Currency),
 			Toowner:    common.HexToAddress(*toowner),
-			Fromowner:  common.HexToAddress(*fromowner),
+			Fromowner:  common.HexToAddress(k),
 			Privatekey: *privatekey,
 			Toamount:   *toamount,
 			Fromamount: uint(p.Amount)}
 		c.SendBasicTransaction(*watcherSubmitURL)
 	case split.FullCommand():
-		//plasma_cli split --fromutxo --fromowner --privatekey --toowner --toamount --watcher --outputs
-		p := plasma.GetUTXO(*sfromowner, *sfromutxo, *swatcherSubmitURL)
-
+		//plasma_cli split --fromutxo --privatekey --toowner --toamount --watcher --outputs
+		k := util.DeriveAddress(*sprivatekey)
+		p := plasma.GetUTXO(k, *sfromutxo, *swatcherSubmitURL)
 		c := plasma.PlasmaTransaction{
 			Blknum:     uint(p.Blknum),
 			Txindex:    uint(p.Txindex),
 			Oindex:     uint(p.Oindex),
 			Cur12:      common.HexToAddress(p.Currency),
 			Toowner:    common.HexToAddress(*stoowner),
-			Fromowner:  common.HexToAddress(*sfromowner),
+			Fromowner:  common.HexToAddress(k),
 			Privatekey: *sprivatekey,
 			Toamount:   *stoamount,
 			Fromamount: uint(p.Amount),
 			Outputs:    int(*outputs)}
 		c.SendSplitTransaction(*swatcherSubmitURL)
 	case merge.FullCommand():
-		//plasma_cli merge --fromutxo=10000 --fromutxo=20000 --watcher="http://foo.path" --privatekey="foo" --fromowner="foo"
+		//plasma_cli merge --fromutxo=10000 --fromutxo=20000 --watcher="http://foo.path" --privatekey="foo"
 		utxos := *mergeFromUtxos
 		var us []plasma.SingleUTXO
+		k := util.DeriveAddress(*mergePrivateKey)
+		log.Info(k)
 		for _, u := range utxos {
-			us = append(us, plasma.GetUTXO(*mergeFromOwner, uint(u), *mergeWatcherURL))
+			us = append(us, plasma.GetUTXO(k, uint(u), *mergeWatcherURL))
 		}
+
 		m := plasma.MergeTransaction{
 			Utxos:      us,
-			Fromowner:  common.HexToAddress(*mergeFromOwner),
+			Fromowner:  common.HexToAddress(k),
 			Privatekey: *mergePrivateKey,
 		}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -110,7 +110,6 @@ func ParseArgs() {
 	case send.FullCommand():
 		//plasma_cli send --fromutxo --fromowner --privatekey --toowner --toamount --watcher
 		p := plasma.GetUTXO(*fromowner, *fromutxo, *watcherSubmitURL)
-		watcher := *watcherSubmitURL
 
 		c := plasma.PlasmaTransaction{
 			Blknum:     uint(p.Blknum),
@@ -122,11 +121,10 @@ func ParseArgs() {
 			Privatekey: *privatekey,
 			Toamount:   *toamount,
 			Fromamount: uint(p.Amount)}
-		c.SendBasicTransaction(watcher)
+		c.SendBasicTransaction(*watcherSubmitURL)
 	case split.FullCommand():
 		//plasma_cli split --fromutxo --fromowner --privatekey --toowner --toamount --watcher --outputs
 		p := plasma.GetUTXO(*sfromowner, *sfromutxo, *swatcherSubmitURL)
-		watcher := *swatcherSubmitURL
 
 		c := plasma.PlasmaTransaction{
 			Blknum:     uint(p.Blknum),
@@ -139,7 +137,7 @@ func ParseArgs() {
 			Toamount:   *stoamount,
 			Fromamount: uint(p.Amount),
 			Outputs:    int(*outputs)}
-		c.SendSplitTransaction(watcher)
+		c.SendSplitTransaction(*swatcherSubmitURL)
 	case merge.FullCommand():
 		//plasma_cli merge --fromutxo=10000 --fromutxo=20000 --watcher="http://foo.path" --privatekey="foo" --fromowner="foo"
 		utxos := *mergeFromUtxos

--- a/plasma/plasma.go
+++ b/plasma/plasma.go
@@ -222,17 +222,14 @@ type SingleUTXO struct {
 	Amount   int    `json:"amount"`
 }
 
-// Create a basic transaction with 1 input splitted into 2 outputs
-// if from == to amount, create single output
+// Create a basic transaction with 1 input and 1 output (2 if contains change)
 func (p *PlasmaTransaction) createBasicTransaction() createdTx {
-	//creates 1 input, 2 outputs tx
 	NULL_ADDRESS := common.HexToAddress("0000000000000000000000000000000000000000")
 	NULL_INPUT := inputUTXO{Blknum: 0, Txindex: 0, Oindex: 0}
 	NULL_OUTPUT := outputUTXO{OwnerAddress: NULL_ADDRESS, Amount: 0, Currency: NULL_ADDRESS}
-	//1 single input
+
 	singleInput := inputUTXO{Blknum: p.Blknum, Txindex: p.Txindex, Oindex: p.Oindex}
-	//output one is value you are sending
-	//output two is the change (NULL OUTPUT if fromamount == to amount)
+
 	var outputOne outputUTXO
 	var outputTwo outputUTXO
 	if p.Fromamount == p.Toamount {
@@ -258,7 +255,7 @@ func (p *PlasmaTransaction) createBasicTransaction() createdTx {
 	return transaction
 }
 
-// form 1 input with N output transactions
+// Create a split transaction with 1 input and N output
 func (p *PlasmaTransaction) createSplitTransaction() createdTx {
 	totalAmount := p.Toamount * uint(p.Outputs)
 	change := int(p.Fromamount) - int(totalAmount)
@@ -301,7 +298,6 @@ func (p *PlasmaTransaction) createSplitTransaction() createdTx {
 			o = append(o, NULL_OUTPUT)
 		}
 	}
-	log.Info(o)
 
 	i = append(i, singleInput, NULL_INPUT, NULL_INPUT, NULL_INPUT)
 	transaction := createdTx{Inputs: i, Outputs: o}
@@ -309,7 +305,7 @@ func (p *PlasmaTransaction) createSplitTransaction() createdTx {
 	return transaction
 }
 
-// form N inputs 1 output transaction
+// Create a merge transaction with 1 input and N output
 func (m *MergeTransaction) createMergeTransaction() createdTx {
 	NULL_ADDRESS := common.HexToAddress("0000000000000000000000000000000000000000")
 	NULL_INPUT := inputUTXO{Blknum: 0, Txindex: 0, Oindex: 0}

--- a/util/util.go
+++ b/util/util.go
@@ -112,6 +112,16 @@ func GenerateAccount() (string, string) {
 	return address, privateKey
 }
 
+// Derive Address from Private Key
+func DeriveAddress(p string) string {
+	key, err := crypto.HexToECDSA(FilterZeroX(p))
+	if err != nil {
+		log.Fatal(err)
+	}
+	addr := crypto.PubkeyToAddress(key.PublicKey).Hex()
+	return addr
+}
+
 // Make strings suitable for hex encoding
 func RemoveLeadingZeroX(item string) string {
 	cleanedString := strings.Replace(item, "0x", "", -1)


### PR DESCRIPTION
https://github.com/omisego/plasma-cli/issues/42

use:

```
plasma_cli split --fromutxo=UTXO_position --fromowner="from_address" --privatekey="from_privatekey" --toowner="to_address" --toamount=to_amount  --outputs=number_of_outputs --watcher="watcher_url"
```

Takes in a single UTXO input - split into N Outputs
- if have change, add change into the next output
- throws error if: 
1. outputs are more than 4
2.  amount to split > from amount

Note: `Split` is reimplementing a lot of function found in `Send` right now. I will refactor all the `PlasmaTransactions` and have them share the same interface later. 